### PR TITLE
Eth 54 migration

### DIFF
--- a/contracts/IERC20Receiver.sol
+++ b/contracts/IERC20Receiver.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.6.6;
+
+/*
+tokenbridge callback function for receiving relayTokensAndCall()
+*/
+interface IERC20Receiver {
+    function onTokenBridged(
+        address token,
+        uint256 value,
+        bytes calldata data
+    ) external;
+}

--- a/contracts/ITokenMediator.sol
+++ b/contracts/ITokenMediator.sol
@@ -7,4 +7,6 @@ interface ITokenMediator {
     //Multi-token mediator: 0xb1516c26 == bytes4(keccak256(abi.encodePacked("multi-erc-to-erc-amb")))
     //Single-token mediator: 0x76595b56 ==  bytes4(keccak256(abi.encodePacked("erc-to-erc-amb")))
     function getBridgeMode() external pure returns (bytes4 _data);
+
+    function relayTokensAndCall(address token, address _receiver, uint256 _value, bytes calldata _data) external;
 }

--- a/contracts/MockTokenMediator.sol
+++ b/contracts/MockTokenMediator.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.6.6;
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./ISingleTokenMediator.sol";
-import "./IMultiTokenMediator.sol";
 
 contract MockTokenMediator is ISingleTokenMediator {
     ERC20 public token;
@@ -28,4 +27,8 @@ contract MockTokenMediator is ISingleTokenMediator {
         require(token.transferFrom(msg.sender, _receiver, _value), "transfer_rejected_in_mock");
     }
 
+    function relayTokensAndCall(address _token, address _receiver, uint256 _value, bytes memory) override public {
+        require(_token == address(token), "wrong_token");
+        relayTokens(_receiver, _value);
+    }
 }

--- a/test/e2e/usingPlainEthers.js
+++ b/test/e2e/usingPlainEthers.js
@@ -11,6 +11,8 @@ const FOREIGN_MULTIMEDIATOR = "0x6346Ed242adE018Bd9320D5E3371c377BAB29c31"
 
 const Token = require("../../build/contracts/IERC20.json")
 const DataUnionSidechain = require("../../build/contracts/DataUnionSidechain.json")
+const DataUnionMainnet = require("../../build/contracts/DataUnionMainnet.json")
+
 const ITokenMediator = require("../../build/contracts/ITokenMediator.json")
 const IMultiTokenMediator = require("../../build/contracts/IMultiTokenMediator.json")
 const IAMB = require("../../build/contracts/IAMB.json")
@@ -84,7 +86,7 @@ describe("Data Union tests using only ethers.js directly", () => {
         sidechainAmb = new Contract(FOREIGN_AMB, IAMB.abi, walletMainnet)
     })
 
-    it("can deploy, add members and withdraw", async function () {
+    it("can deploy, add members and withdraw, migrate and withdraw in new token", async function () {
         this.timeout(process.env.TEST_TIMEOUT || 300000)
         const member = "0x4178baBE9E5148c6D5fd431cD72884B07Ad855a0"
         const member2 = "0x0101010101010101010010101010101001010101"
@@ -108,7 +110,7 @@ describe("Data Union tests using only ethers.js directly", () => {
         await printStats(duSidechain, member)
         await testSend(duMainnet, duSidechain, sendAmount)
         await printStats(duSidechain, member)
-        await withdraw(erc20Mainnet, duSidechain, member)
+        await withdraw(duSidechain, member)
         await printStats(duSidechain, member)
 
         const balanceAfter = await erc20Mainnet.balanceOf(member)
@@ -134,33 +136,44 @@ describe("Data Union tests using only ethers.js directly", () => {
             return false
         }, 360000)
         let tx
+        log("migrate DU sidechain")
         tx = await sidechainMigrationMgr.setCurrentToken(homeAddress)
         await tx.wait()
         tx = await sidechainMigrationMgr.setOldToken(erc677Sidechain.address)
         await tx.wait()
         tx = await sidechainMigrationMgr.setCurrentMediator(HOME_MULTIMEDIATOR)
         await tx.wait()
-        log("migrate DU sidechain")
         tx = await duSidechain.migrate({gasLimit: 4000000})
         await tx.wait()
         log("migrated")
-        await withdraw(testToken, duSidechain, member2)
+
+        log("migrate DU mainnet")
+        tx = await mainnetMigrationMgr.setCurrentToken(testToken.address)
+        await tx.wait()
+        tx = await mainnetMigrationMgr.setCurrentMediator(FOREIGN_MULTIMEDIATOR)
+        await tx.wait()
+        tx = await duMainnet.migrate({gasLimit: 4000000})
+        await tx.wait()
+        log("migrated")
+        
+        await withdraw(duSidechain, member2)
         const balanceAfter2 = await testToken.balanceOf(member2)
         log("checking balance in new token on mainnet")
         assert(balanceAfter2.eq(BigNumber.from(sendAmount).div(2)))
     })
-
 
 })
 
 // goes over bridge => extra wait
 // duSidechain needed just for the wait!
 async function testSend(duMainnet, duSidechain, tokenWei) {
-    const bal = await erc20Mainnet.balanceOf(walletMainnet.address)
+    const [mainnetToken, sidechainToken] = await getTokenContracts(duMainnet)
+
+    const bal = await mainnetToken.balanceOf(walletMainnet.address)
     log(`User wallet mainnet balance ${bal}`)
 
     //transfer ERC20 to mainet contract
-    const tx1 = await erc20Mainnet.transfer(duMainnet.address, tokenWei)
+    const tx1 = await mainnetToken.transfer(duMainnet.address, tokenWei)
     await tx1.wait()
     log(`Transferred ${tokenWei} to ${duMainnet.address}, sending to bridge`)
 
@@ -174,7 +187,7 @@ async function testSend(duMainnet, duSidechain, tokenWei) {
 
     await until(async () => {
         try {
-            const ercbal = await erc677Sidechain.balanceOf(duSidechain.address)
+            const ercbal = await sidechainToken.balanceOf(duSidechain.address)
             let rslt = !duSideBalanceBefore.eq(await duSidechain.totalEarnings())
             log(`Sidechain ERC677 balance ${ercbal} ${rslt}`)
             return rslt
@@ -188,9 +201,45 @@ async function testSend(duMainnet, duSidechain, tokenWei) {
     log(`Confirmed DU sidechain balance ${duSideBalanceBefore} -> ${await duSidechain.totalEarnings()}`)
 }
 
-// goes over bridge => extra wait
-async function withdraw(mainnetToken, duSidechain, member) {
+async function getSidechainDu(mainnetDu){
+    const sidechainDu = await mainnetDu.sidechainAddress()
+    return new Contract(
+        sidechainDu,
+        DataUnionSidechain.abi,
+        walletSidechain
+    )
+}
 
+async function getMainnetDu(sidechainDu){
+    const mainnetDu = await sidechainDu.dataUnionMainnet()
+    return new Contract(
+        mainnetDu,
+        DataUnionMainnet.abi,
+        walletMainnet
+    )
+}
+
+async function getTokenContracts(mainnetDu){
+    const mainnetTokenAddress = await mainnetDu.token()
+    const mainnetToken = new Contract(
+        mainnetTokenAddress,
+        Token.abi,
+        walletMainnet
+    )
+    const sidechainDu = await getSidechainDu(mainnetDu)
+    const sidechainTokenAddress = await sidechainDu.token()
+    const sidechainToken = new Contract(
+        sidechainTokenAddress,
+        Token.abi,
+        walletSidechain
+    ) 
+    return [mainnetToken, sidechainToken]
+}
+
+// goes over bridge => extra wait
+async function withdraw(duSidechain, member) {
+    const duMainnet = await getMainnetDu(duSidechain)
+    const [mainnetToken, sidechainToken] = await getTokenContracts(duMainnet)
     const balanceBefore = await mainnetToken.balanceOf(member)
     const earnings = await duSidechain.getWithdrawableEarnings(member)
     log(`withdraw for ${member} (mainnet balance ${balanceBefore}) (earnings ${earnings})`)
@@ -268,9 +317,12 @@ async function deployTestToken(wallet, amt) {
 }
 
 async function printStats(duSidechain, member) {
-    const bal1 = await erc20Mainnet.balanceOf(member)
+    const duMainnet = await getMainnetDu(duSidechain)
+    const [mainnetToken, sidechainToken] = await getTokenContracts(duMainnet)
+    log(`mainnetToken ${mainnetToken.address} sidechainToken ${sidechainToken.address}`)
+    const bal1 = await mainnetToken.balanceOf(member)
     log(`${member} mainnet balance ${bal1}`)
-    const bal2 = await erc677Sidechain.balanceOf(member)
+    const bal2 = await sidechainToken.balanceOf(member)
     log(`${member} side-chain balance ${bal2}`)
 
     const memberData = await duSidechain.memberData(member)
@@ -283,6 +335,6 @@ async function printStats(duSidechain, member) {
         log(`${member} side-chain total earnings ${bal4}`)
     }
 
-    const bal5 = await erc677Sidechain.balanceOf(duSidechain.address)
+    const bal5 = await sidechainToken.balanceOf(duSidechain.address)
     log(`side-chain DU ${duSidechain.address} token balance ${bal5}`)
 }

--- a/test/e2e/usingPlainEthers.js
+++ b/test/e2e/usingPlainEthers.js
@@ -212,7 +212,7 @@ async function testSend(duMainnet, duSidechain, tokenWei) {
     log(`Confirmed DU sidechain balance ${duSideBalanceBefore} -> ${await duSidechain.totalEarnings()}`)
 }
 
-async function getSidechainDu(mainnetDu){
+async function getSidechainDu(mainnetDu) {
     const sidechainDu = await mainnetDu.sidechainAddress()
     return new Contract(
         sidechainDu,
@@ -221,7 +221,7 @@ async function getSidechainDu(mainnetDu){
     )
 }
 
-async function getMainnetDu(sidechainDu){
+async function getMainnetDu(sidechainDu) {
     const mainnetDu = await sidechainDu.dataUnionMainnet()
     return new Contract(
         mainnetDu,
@@ -230,7 +230,7 @@ async function getMainnetDu(sidechainDu){
     )
 }
 
-async function getTokenContracts(mainnetDu){
+async function getTokenContracts(mainnetDu) {
     const mainnetTokenAddress = await mainnetDu.token()
     const mainnetToken = new Contract(
         mainnetTokenAddress,
@@ -250,7 +250,7 @@ async function getTokenContracts(mainnetDu){
 // goes over bridge => extra wait
 async function withdraw(duSidechain, member) {
     const duMainnet = await getMainnetDu(duSidechain)
-    const [mainnetToken, sidechainToken] = await getTokenContracts(duMainnet)
+    const [mainnetToken, ] = await getTokenContracts(duMainnet)
     const balanceBefore = await mainnetToken.balanceOf(member)
     const earnings = await duSidechain.getWithdrawableEarnings(member)
     log(`withdraw for ${member} (mainnet balance ${balanceBefore}) (earnings ${earnings})`)


### PR DESCRIPTION
- add `onTokensBridged` handler for OmniBridge `relayTokensAndCall`. All mediators use same `relayTokensAndCall` interface.
- end to end test with OmniBridge migration, sends new token from mainnet

Note integration test requires **new parity images** (in PR) to pass.
