### PR TITLE
no nonce arg needed in setBinanceRecipientFromSig

### DIFF
--- a/contracts/BinanceAdapter.sol
+++ b/contracts/BinanceAdapter.sol
@@ -51,14 +51,13 @@ contract BinanceAdapter {
     deadline is a timestamp to prevent replay attacks
     */
 
-    function setBinanceRecipientFromSig(address from, address recipient, uint256 nonce, bytes memory sig) public {
+    function setBinanceRecipientFromSig(address from, address recipient, bytes memory sig) public {
         UserData storage userdata = binanceRecipient[from];
-        require(nonce == userdata.nonce.add(1), "nonce_too_low");
-        require(getSigner(recipient, nonce, sig) == from, "bad_signature");
-        userdata.nonce = nonce;
+        uint nextNonce = userdata.nonce.add(1);
+        require(getSigner(recipient, nextNonce, sig) == from, "bad_signature");
+        userdata.nonce = nextNonce;
         _setBinanceRecipient(from, recipient);
-    }
-    
+    }    
 
     function _setBinanceRecipient(address member, address recipient) internal {
         UserData storage userdata = binanceRecipient[member];

--- a/test/contracts/BinanceAdapter.js
+++ b/test/contracts/BinanceAdapter.js
@@ -109,11 +109,11 @@ contract("BinanceAdapter", accounts => {
         nonce = nonce.add(new BN(1))
         const sig = await makeSetBinanceRecipientSignature(members[2], nonce, adapter.address, members[1])
         //console.log(`nonce ${nonce} sig ${sig} ${members[1]} ${members[2]}`)
-        await adapter.setBinanceRecipientFromSig(members[1], members[2], nonce, sig, {from: members[0]})
+        await adapter.setBinanceRecipientFromSig(members[1], members[2], sig, {from: members[0]})
         assertEqual(members[2], (await adapter.binanceRecipient(members[1]))[0])
 
         //replay should fail
-        await assertFails(adapter.setBinanceRecipientFromSig(members[1], members[2], nonce, sig, {from: members[0]}))
+        await assertFails(adapter.setBinanceRecipientFromSig(members[1], members[2], sig, {from: members[0]}))
     }),
     it("can withdraw to mediator without conversion", async () => {
         let adapter = await BinanceAdapter.new(testToken.address, zeroAddress, mockBinanceMediator.address, zeroAddress, zeroAddress, {from: creator }) 


### PR DESCRIPTION
`setBinanceRecipientFromSig` does not need to be passed `nonce` explicitly. Contract knows the next nonce and can tell if signature matches it. This interface is cleaner.